### PR TITLE
Update docker analyzer name

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,7 +1,7 @@
 version = 1
 
 [[analyzers]]
-name = "dockerfile"
+name = "docker"
 enabled = true
 
   [analyzers.meta]


### PR DESCRIPTION
This PR changes the name of the analyzer from `dockerfile` to `docker`.

We recently launched the `Docker` analyzer which was in the Beta mode till now. In the final release, we have changed the name of the analyzer from `dockerfile` to `docker`.
